### PR TITLE
Correction for shotgun prop_* classname detection

### DIFF
--- a/lua/autorun/client/tf2_multifix_client.lua
+++ b/lua/autorun/client/tf2_multifix_client.lua
@@ -34,7 +34,7 @@ hook.Add("Initialize", "TF2ParticleFix", function() timer.Simple(2.5, function()
 
 hook.Add("OnEntityCreated", "TF2ShotgunFix", function (ent)
 	if (ent:IsValid()) then
-		if (string.gmatch(ent:GetClass(), "prop_.*") && ent:GetModel() == "models/weapons/w_models/w_shotgun.mdl") then
+		if (string.StartsWith(ent:GetClass(), "prop_") && ent:GetModel() == "models/weapons/w_models/w_shotgun.mdl") then
 			ent:SetMaterial("tf_replacements/weapon_shotgun")
 		end
 	end


### PR DESCRIPTION
I highly suspect `string.gmatch` was used by mistake, since it always returns an iterator function, which means that the shotgun material fix would be applied regardless of entity classname. My proposed fix is to use `string.StartsWith` instead.